### PR TITLE
fix Nullpointer when returned intent is null

### DIFF
--- a/android/src/main/kotlin/com/homex/open_mail_app/OpenMailAppPlugin.kt
+++ b/android/src/main/kotlin/com/homex/open_mail_app/OpenMailAppPlugin.kt
@@ -93,15 +93,16 @@ class OpenMailAppPlugin : FlutterPlugin, MethodCallHandler {
             for (i in 1 until activitiesHandlingEmails.size) {
                 val activityHandlingEmail = activitiesHandlingEmails[i]
                 val packageName = activityHandlingEmail.activityInfo.packageName
-                val intent = packageManager.getLaunchIntentForPackage(packageName)
-                emailInboxIntents.add(
-                        LabeledIntent(
-                                intent,
-                                packageName,
-                                activityHandlingEmail.loadLabel(packageManager),
-                                activityHandlingEmail.icon
-                        )
-                )
+                packageManager.getLaunchIntentForPackage(packageName)?.let { intent ->
+                    emailInboxIntents.add(
+                            LabeledIntent(
+                                    intent,
+                                    packageName,
+                                    activityHandlingEmail.loadLabel(packageManager),
+                                    activityHandlingEmail.icon
+                            )
+                    )
+                }
             }
             val extraEmailInboxIntents = emailInboxIntents.toTypedArray()
             val finalIntent = emailAppChooserIntent.putExtra(Intent.EXTRA_INITIAL_INTENTS, extraEmailInboxIntents)


### PR DESCRIPTION
When querying apps capable of opening `mailto:` action on Android, often system adds one more, [dummy Activity to handle various common intents](https://android.googlesource.com/platform/development/+/master/apps/Fallback/src/com/android/fallback/Fallback.java), which is not accessible trough intent, thus a call to `packageManager.getLaunchIntentForPackage(packageName)` causes the following exception:

```
E/MethodChannel#open_mail_app( 4761): Failed to handle method call
E/MethodChannel#open_mail_app( 4761): java.lang.NullPointerException: Attempt to read from field 'java.lang.String android.content.Intent.mAction' on a null object reference
E/MethodChannel#open_mail_app( 4761): 	at android.content.Intent.<init>(Intent.java:4768)
E/MethodChannel#open_mail_app( 4761): 	at android.content.pm.LabeledIntent.<init>(LabeledIntent.java:63)
E/MethodChannel#open_mail_app( 4761): 	at com.homex.open_mail_app.OpenMailAppPlugin.emailAppIntent(OpenMailAppPlugin.kt:98)
E/MethodChannel#open_mail_app( 4761): 	at com.homex.open_mail_app.OpenMailAppPlugin.onMethodCall(OpenMailAppPlugin.kt:54)
E/MethodChannel#open_mail_app( 4761): 	at io.flutter.plugin.common.MethodChannel$IncomingMethodCallHandler.onMessage(MethodChannel.java:230)
E/MethodChannel#open_mail_app( 4761): 	at io.flutter.embedding.engine.dart.DartMessenger.handleMessageFromDart(DartMessenger.java:85)
E/MethodChannel#open_mail_app( 4761): 	at io.flutter.embedding.engine.FlutterJNI.handlePlatformMessage(FlutterJNI.java:650)
E/MethodChannel#open_mail_app( 4761): 	at android.os.MessageQueue.nativePollOnce(Native Method)
E/MethodChannel#open_mail_app( 4761): 	at android.os.MessageQueue.next(MessageQueue.java:323)
E/MethodChannel#open_mail_app( 4761): 	at android.os.Looper.loop(Looper.java:136)
E/MethodChannel#open_mail_app( 4761): 	at android.app.ActivityThread.main(ActivityThread.java:6077)
E/MethodChannel#open_mail_app( 4761): 	at java.lang.reflect.Method.invoke(Native Method)
E/MethodChannel#open_mail_app( 4761): 	at com.android.internal.os.ZygoteInit$MethodAndArgsCaller.run(ZygoteInit.java:866)
E/MethodChannel#open_mail_app( 4761): 	at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:756)
E/flutter ( 4761): [ERROR:flutter/lib/ui/ui_dart_state.cc(166)] Unhandled Exception: PlatformException(error, Attempt to read from field 'java.lang.String android.content.Intent.mAction' on a null object reference, null)
```

To fix that, I've added a simple null-check to filter out such scenarios