### PR TITLE
support parametric title in the native app chooser for Android

### DIFF
--- a/android/src/main/kotlin/com/homex/open_mail_app/OpenMailAppPlugin.kt
+++ b/android/src/main/kotlin/com/homex/open_mail_app/OpenMailAppPlugin.kt
@@ -52,7 +52,7 @@ class OpenMailAppPlugin : FlutterPlugin, MethodCallHandler {
 
     override fun onMethodCall(@NonNull call: MethodCall, @NonNull result: Result) {
         if (call.method == "openMailApp") {
-            val opened = emailAppIntent()
+            val opened = emailAppIntent(call.argument("chooserTitle")!!)
             if (opened) {
                 result.success(true)
             } else {
@@ -78,7 +78,7 @@ class OpenMailAppPlugin : FlutterPlugin, MethodCallHandler {
         channel.setMethodCallHandler(null)
     }
 
-    private fun emailAppIntent(): Boolean {
+    private fun emailAppIntent(@NonNull chooserTitle: String): Boolean {
         val emailIntent = Intent(Intent.ACTION_VIEW, Uri.parse("mailto:"))
         val packageManager = applicationContext.packageManager
 
@@ -87,7 +87,7 @@ class OpenMailAppPlugin : FlutterPlugin, MethodCallHandler {
             // use the first email package to create the chooserIntent
             val firstEmailPackageName = activitiesHandlingEmails.first().activityInfo.packageName
             val firstEmailInboxIntent = packageManager.getLaunchIntentForPackage(firstEmailPackageName)
-            val emailAppChooserIntent = Intent.createChooser(firstEmailInboxIntent, "")
+            val emailAppChooserIntent = Intent.createChooser(firstEmailInboxIntent, chooserTitle)
 
             // created UI for other email packages and add them to the chooser
             val emailInboxIntents = mutableListOf<LabeledIntent>()

--- a/lib/open_mail_app.dart
+++ b/lib/open_mail_app.dart
@@ -24,9 +24,12 @@ class OpenMailApp {
   /// the user to pick the mail app they want to open.
   ///
   /// Also see [openSpecificMailApp] and [getMailApps] for other use cases.
-  static Future<OpenMailAppResult> openMailApp() async {
+  static Future<OpenMailAppResult> openMailApp({String chooserTitle = ''}) async {
     if (Platform.isAndroid) {
-      var result = await _channel.invokeMethod<bool>('openMailApp');
+      var result = await _channel.invokeMethod<bool>(
+        'openMailApp',
+        <String, dynamic>{'chooserTitle': chooserTitle},
+      );
       return OpenMailAppResult(didOpen: result);
     } else if (Platform.isIOS) {
       var apps = await _getIosMailApps();


### PR DESCRIPTION
### Usage

```dart
await OpenMailApp.openMailApp(chooserTitle: chooserTitle);
```

### Result
<img width="361" alt="image" src="https://user-images.githubusercontent.com/3502356/103218984-c51f3200-491c-11eb-819b-922d9e953265.png">


**BREAKING CHANGE**: no
Closes https://github.com/HomeXLabs/open-mail-app-flutter/issues/16