### PR TITLE
Opens selected mail app with pre-filled compose fields.

### DIFF
--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -62,6 +62,34 @@ class MyApp extends StatelessWidget {
                 }
               },
             ),
+            RaisedButton(
+              child: Text("Compose from Mail App"),
+              onPressed: () async {
+                // Android: Will open mail app or show native picker.
+                // iOS: Will open mail app if single mail app found.
+                var result = await OpenMailApp.openMailApp(
+                  nativePickerTitle: 'Select email app to compose from',
+                );
+
+                // If no mail apps found, show error
+                if (!result.didOpen && !result.canOpen) {
+                  showNoMailAppsDialog(context);
+
+                  // iOS: if multiple mail apps found, show dialog to select.
+                  // There is no native intent/default app system in iOS so
+                  // you have to do it yourself.
+                } else if (!result.didOpen && result.canOpen) {
+                  showDialog(
+                    context: context,
+                    builder: (_) {
+                      return MailAppPickerToComposeDialog(
+                        mailApps: result.options,
+                      );
+                    },
+                  );
+                }
+              },
+            ),
           ],
         ),
       ),

--- a/lib/open_mail_app.dart
+++ b/lib/open_mail_app.dart
@@ -63,6 +63,49 @@ class OpenMailApp {
     }
   }
 
+  /// Attempts to open a specific email app installed on the device.
+  /// Get a [MailApp] from calling [getMailApps]
+  static Future<bool> composeFromSpecificMailApp(MailApp mailApp,
+      {String message, String recipient, String subject}) async {
+    if (Platform.isAndroid) {
+      var result = await _channel.invokeMethod<bool>(
+        'openSpecificMailApp',
+        <String, dynamic>{'name': mailApp.name},
+      );
+      return result;
+    } else if (Platform.isIOS) {
+      if (mailApp.name == 'Outlook') {
+        return await launch(
+            '${mailApp.iosLaunchScheme}compose?to=$recipient&subject=$subject&body=$message');
+      } else if (mailApp.name == 'Gmail') {
+        return await launch(
+            '${mailApp.iosLaunchScheme}/co?to=$recipient&subject=$subject&body=$message');
+      } else if (mailApp.name == 'Spark') {
+        return await launch(
+            '${mailApp.iosLaunchScheme}compose?recipient=$recipient&subject=$subject&body=$message');
+      } else if (mailApp.name == 'Yahoo') {
+        return await launch(
+            '${mailApp.iosLaunchScheme}compose?to=$recipient&subject=$subject&body=$message');
+      } else if (mailApp.name == 'Fastmail') {
+        return await launch(
+            '${mailApp.iosLaunchScheme}mail/compose?to=$recipient&subject=$subject&body=$message');
+      } else if (mailApp.name == 'Default Mail App') {
+        return await launch(
+            'mailto:?to=$recipient&subject=$subject&body=$message');
+      } else if (mailApp.name == 'Dispatch') {
+        return await launch(
+            '${mailApp.iosLaunchScheme}/compose?to=$recipient&subject=$subject&body=$message');
+      } else if (mailApp.name == 'Airmail') {
+        return await launch(
+            '${mailApp.iosLaunchScheme}compose?to=$recipient&subject=$subject&plainBody=$message');
+      } else {
+        return await launch(mailApp.iosLaunchScheme);
+      }
+    } else {
+      throw Exception('Platform not supported');
+    }
+  }
+
   /// Returns a list of installed email apps on the device
   ///
   /// iOS: [MailApp.iosLaunchScheme] will be populated
@@ -117,6 +160,44 @@ class MailAppPickerDialog extends StatelessWidget {
             child: Text(app.name),
             onPressed: () {
               OpenMailApp.openSpecificMailApp(app);
+              Navigator.pop(context);
+            },
+          ),
+      ],
+    );
+  }
+}
+
+class MailAppPickerToComposeDialog extends StatelessWidget {
+  /// The title of the dialog
+  final String title;
+  final String message;
+  final String recipient;
+  final String subject;
+
+  /// The mail apps for the dialog to provide as options
+  final List<MailApp> mailApps;
+
+  const MailAppPickerToComposeDialog({
+    Key key,
+    this.title = 'Choose Mail App',
+    this.message,
+    this.subject,
+    this.recipient,
+    @required this.mailApps,
+  }) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    return SimpleDialog(
+      title: Text(title),
+      children: <Widget>[
+        for (var app in mailApps)
+          SimpleDialogOption(
+            child: Text(app.name),
+            onPressed: () {
+              OpenMailApp.composeFromSpecificMailApp(app,
+                  message: message, recipient: recipient, subject: subject);
               Navigator.pop(context);
             },
           ),

--- a/lib/open_mail_app.dart
+++ b/lib/open_mail_app.dart
@@ -85,7 +85,7 @@ class OpenMailApp {
             '${mailApp.iosLaunchScheme}compose?recipient=$recipient&subject=$subject&body=$message');
       } else if (mailApp.name == 'Yahoo') {
         return await launch(
-            '${mailApp.iosLaunchScheme}compose?to=$recipient&subject=$subject&body=$message');
+            '${mailApp.iosLaunchScheme}mail/compose?to=$recipient&subject=$subject&body=$message');
       } else if (mailApp.name == 'Fastmail') {
         return await launch(
             '${mailApp.iosLaunchScheme}mail/compose?to=$recipient&subject=$subject&body=$message');

--- a/lib/open_mail_app.dart
+++ b/lib/open_mail_app.dart
@@ -63,7 +63,7 @@ class OpenMailApp {
     }
   }
 
-  /// Attempts to open a specific email app installed on the device.
+  /// Attempts to open a specific email app installed on the device, and pre-fill the compose screen with user-generated fields.
   /// Get a [MailApp] from calling [getMailApps]
   static Future<bool> composeFromSpecificMailApp(MailApp mailApp,
       {String message, String recipient, String subject}) async {


### PR DESCRIPTION
Hey guys, I'm a noob at Flutter but I really needed this capability. Basically it launches the Picker dialog with optional Subject, To, and Body fields and when you select it, it moves into that app's compose screen. I couldn't make it work to launch specifically the Apple Mail app if they didn't already have it as default, but that shouldn't be a problem because why would anyone who doesn't have it as default already actually want to use Mail....

I saw you were having some issues figuring it out and went ahead to scour the internet for the proper URL schemes for each one of these. 

It works on my physical device for my purposes, so hopefully you can incorporate this into the actual plugin for others to use!

Thanks so much. I wanted to pay it forward and hope this helps!