### PR TITLE
Open email app in compose view with content

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,42 +1,50 @@
+## 0.2.0
+
+- Added possibility to call a specific email app and compose a new email.
+
 ## 0.1.1
 
-* Added optional list for filtering mail apps by name.
+- Added optional list for filtering mail apps by name.
 
 ## 0.1.0
 
-* Null safety stable release
+- Null safety stable release
 
 ## 0.0.8
+
 Thanks to martyfuhry for the following fix
 
-* Fixed opening mail apps not working on Android when targetSdkVersion is 30
+- Fixed opening mail apps not working on Android when targetSdkVersion is 30
 
 ## 0.0.7
+
 Thanks to PrinceGoyal for the following improvement
 
-* Update gradle to 6.7.1 from 5.6.2
+- Update gradle to 6.7.1 from 5.6.2
 
 ## 0.0.6
+
 Thanks to nerder for the following feature
 
-* Added the option to set the title of the native picker for Android
-* Added title parameter for MailAppPickerDialog
+- Added the option to set the title of the native picker for Android
+- Added title parameter for MailAppPickerDialog
 
 ## 0.0.5
 
-* Fixed MailApp name being null when building on Android when minifyEnabled is set to true
+- Fixed MailApp name being null when building on Android when minifyEnabled is set to true
 
 ## 0.0.3
+
 Thanks to andrzejchm for the following bug fix.
 
-* Fix null pointer exception on Android
+- Fix null pointer exception on Android
 
 ## 0.0.2
 
-* Update description in pubspec
+- Update description in pubspec
 
 ## 0.0.1
 
-* Initial release.
-* Open email apps
-* Get list of installed email apps
+- Initial release.
+- Open email apps
+- Get list of installed email apps

--- a/android/src/main/kotlin/com/homex/open_mail_app/OpenMailAppPlugin.kt
+++ b/android/src/main/kotlin/com/homex/open_mail_app/OpenMailAppPlugin.kt
@@ -14,7 +14,6 @@ import io.flutter.plugin.common.MethodChannel
 import io.flutter.plugin.common.MethodChannel.MethodCallHandler
 import io.flutter.plugin.common.MethodChannel.Result
 import io.flutter.plugin.common.PluginRegistry.Registrar
-import java.net.URLDecoder
 
 class OpenMailAppPlugin : FlutterPlugin, MethodCallHandler {
     private lateinit var channel: MethodChannel
@@ -54,32 +53,16 @@ class OpenMailAppPlugin : FlutterPlugin, MethodCallHandler {
     override fun onMethodCall(@NonNull call: MethodCall, @NonNull result: Result) {
         if (call.method == "openMailApp") {
             val opened = emailAppIntent(call.argument("nativePickerTitle") ?: "")
-            if (opened) {
-                result.success(true)
-            } else {
-                result.success(false)
-            }
+            result.success(opened)
         } else if (call.method == "openSpecificMailApp" && call.hasArgument("name")) {
             val opened = specificEmailAppIntent(call.argument("name")!!)
-            if (opened) {
-                result.success(true)
-            } else {
-                result.success(false)
-            }
+            result.success(opened)
         } else if (call.method == "composeNewEmailInMailApp") {
             val opened = composeNewEmailAppIntent(call.argument("nativePickerTitle") ?: "", call.argument("emailContent") ?: "")
-            if (opened) {
-                result.success(true)
-            } else {
-                result.success(false)
-            }
+            result.success(opened)
         } else if (call.method == "composeNewEmailInSpecificMailApp") {
             val opened = composeNewEmailInSpecificEmailAppIntent(call.argument("name") ?: "", call.argument("emailContent") ?: "")
-            if (opened) {
-                result.success(true);
-            } else {
-                result.success(false);
-            }
+            result.success(opened)
         } else if (call.method == "getMainApps") {
             val apps = getInstalledMailApps()
             val appsJson = Gson().toJson(apps)
@@ -176,7 +159,7 @@ class OpenMailAppPlugin : FlutterPlugin, MethodCallHandler {
             val finalIntent = emailAppChooserIntent.putExtra(Intent.EXTRA_INITIAL_INTENTS, extraEmailComposingIntents)
             finalIntent.flags = Intent.FLAG_ACTIVITY_NEW_TASK
             applicationContext.startActivity(finalIntent)
-            return true;
+            return true
         } else {
             return false
         }
@@ -223,9 +206,8 @@ class OpenMailAppPlugin : FlutterPlugin, MethodCallHandler {
 
         composeEmailIntent.flags = Intent.FLAG_ACTIVITY_NEW_TASK
         applicationContext.startActivity(composeEmailIntent)
+        
         return true
-
-        return true;
     }
 
     private fun getInstalledMailApps(): List<App> {

--- a/android/src/main/kotlin/com/homex/open_mail_app/OpenMailAppPlugin.kt
+++ b/android/src/main/kotlin/com/homex/open_mail_app/OpenMailAppPlugin.kt
@@ -14,6 +14,7 @@ import io.flutter.plugin.common.MethodChannel
 import io.flutter.plugin.common.MethodChannel.MethodCallHandler
 import io.flutter.plugin.common.MethodChannel.Result
 import io.flutter.plugin.common.PluginRegistry.Registrar
+import java.net.URLDecoder
 
 class OpenMailAppPlugin : FlutterPlugin, MethodCallHandler {
     private lateinit var channel: MethodChannel
@@ -66,18 +67,18 @@ class OpenMailAppPlugin : FlutterPlugin, MethodCallHandler {
                 result.success(false)
             }
         } else if (call.method == "composeNewEmailInMailApp") {
-            val opened = composeNewEmailAppIntent(call.argument("nativePickerTitle") ?: "", call.argument("emailContent"))
+            val opened = composeNewEmailAppIntent(call.argument("nativePickerTitle") ?: "", call.argument("emailContent") ?: "")
             if (opened) {
                 result.success(true)
             } else {
                 result.success(false)
             }
         } else if (call.method == "composeNewEmailInSpecificMailApp") {
-            val openend = composeNewEmailInSpecificEmailAppIntent(call.argument("name"), call.argument("emailContent"))
+            val opened = composeNewEmailInSpecificEmailAppIntent(call.argument("name") ?: "", call.argument("emailContent") ?: "")
             if (opened) {
                 result.success(true);
             } else {
-                result.succes(false);
+                result.success(false);
             }
         } else if (call.method == "getMainApps") {
             val apps = getInstalledMailApps()
@@ -129,47 +130,50 @@ class OpenMailAppPlugin : FlutterPlugin, MethodCallHandler {
         }
     }
 
-    private fun composeNewEmailAppIntent(@NonNull chooserTitle: String, @NonNull contentJson: string): Boolean {
+    private fun composeNewEmailAppIntent(@NonNull chooserTitle: String, @NonNull contentJson: String): Boolean {
         val packageManager = applicationContext.packageManager
         val emailContent = Gson().fromJson(contentJson, EmailContent::class.java)
-        val emailIntent = Intent(Intent.ACTION_SENDTO).apply {
-            data = Uri.parse("mailto:")
-            putExtra(Intent.EXTRA_EMAIL, emailContent.to)
-            putExtra(Intent.EXTRA_CC, emailContent.cc)
-            putExtra(Intent.EXTRA_BCC, emailContent.bcc)
-            putExtra(Intent.EXTRA_SUBJECT, emailContent.subject)
-            putExtra(Intent.EXTRA_TEXT, emailContent.body)
-        }
+        val emailIntent = Intent(Intent.ACTION_SENDTO, Uri.parse("mailto:"))
 
         val activitiesHandlingEmails = packageManager.queryIntentActivities(emailIntent, 0)
         if (activitiesHandlingEmails.isNotEmpty()) {
-            val firstEmailPackageName = activitiesHandlingEmails.first().activityInfo.packageName
-            val firstEmailComposeIntent = packageManager.getLaunchIntentForPackage(firstEmailPackageName)
-            val emailAppChooserIntent = Intent.createChooser(firstEmailComposeIntent, chooserTitle)
+            val emailAppChooserIntent = Intent.createChooser(Intent(Intent.ACTION_SENDTO).apply {
+                data = Uri.parse("mailto:")
+                type = "text/plain"
+                setClassName(activitiesHandlingEmails.first().activityInfo.packageName, activitiesHandlingEmails.first().activityInfo.name)
+
+                putExtra(Intent.EXTRA_EMAIL, emailContent.to.toTypedArray())
+                putExtra(Intent.EXTRA_CC, emailContent.cc.toTypedArray())
+                putExtra(Intent.EXTRA_BCC, emailContent.bcc.toTypedArray())
+                putExtra(Intent.EXTRA_SUBJECT, emailContent.subject)
+                putExtra(Intent.EXTRA_TEXT, emailContent.body)
+            }, chooserTitle)
 
             val emailComposingIntents = mutableListOf<LabeledIntent>()
             for (i in 1 until activitiesHandlingEmails.size) {
                 val activityHandlingEmail = activitiesHandlingEmails[i]
                 val packageName = activityHandlingEmail.activityInfo.packageName
-                packageManager.getLaunchIntentForPackage(packageName)?.let { intent ->
                     emailComposingIntents.add(
-                        intent.putExtra(Intent.EXTRA_EMAIL, emailContent.to)
-                        intent.putExtra(Intent.EXTRA_CC, emailContent.cc)
-                        intent.putExtra(Intent.EXTRA_BCC, emailContent.bcc)
-                        intent.putExtra(Intent.EXTRA_SUBJECT, emailContent.subject)
-                        intent.putExtra(Intent.EXTRA_TEXT, emailContent.body)
                         LabeledIntent(
-                            intent  
+                                Intent(Intent.ACTION_SENDTO).apply {
+                                    data = Uri.parse("mailto:")
+                                    type = "text/plain"
+                                    setClassName(activityHandlingEmail.activityInfo.packageName, activityHandlingEmail.activityInfo.name)
+                                    putExtra(Intent.EXTRA_EMAIL, emailContent.to.toTypedArray())
+                                    putExtra(Intent.EXTRA_CC, emailContent.cc.toTypedArray())
+                                    putExtra(Intent.EXTRA_BCC, emailContent.bcc.toTypedArray())
+                                    putExtra(Intent.EXTRA_SUBJECT, emailContent.subject)
+                                    putExtra(Intent.EXTRA_TEXT, emailContent.body)
+                                },
                             packageName, 
                             activityHandlingEmail.loadLabel(packageManager),
                             activityHandlingEmail.icon
-                        ), 
+                        )
                     )
-                }
             }
 
-            val extraEmailComposingIntents = mutableListOf<LabeledIntent>()
-            val finalIntent = emailAppChooserIntent.putExtra(Intent.EXTRA_INITIAL_INTENTS, extraEmailInboxIntents)
+            val extraEmailComposingIntents = emailComposingIntents.toTypedArray()
+            val finalIntent = emailAppChooserIntent.putExtra(Intent.EXTRA_INITIAL_INTENTS, extraEmailComposingIntents)
             finalIntent.flags = Intent.FLAG_ACTIVITY_NEW_TASK
             applicationContext.startActivity(finalIntent)
             return true;
@@ -199,22 +203,23 @@ class OpenMailAppPlugin : FlutterPlugin, MethodCallHandler {
     private fun composeNewEmailInSpecificEmailAppIntent(@NonNull name: String, @NonNull contentJson: String): Boolean {
         val packageManager = applicationContext.packageManager
         val emailContent = Gson().fromJson(contentJson, EmailContent::class.java)
-        val emailIntent = Intent(Intent.ACTION_SENDTO).apply {
-            data = Uri.parse("mailto:")
-            putExtra(Intent.EXTRA_EMAIL, emailContent.to)
-            putExtra(Intent.EXTRA_CC, emailContent.cc)
-            putExtra(Intent.EXTRA_BCC, emailContent.bcc)
-            putExtra(Intent.EXTRA_SUBJECT, emailContent.subject)
-            putExtra(Intent.EXTRA_TEXT, emailContent.body)
-        }
+        val emailIntent = Intent(Intent.ACTION_SENDTO, Uri.parse("mailto:"))
 
         val activitiesHandlingEmails = packageManager.queryIntentActivities(emailIntent, 0)
         val specificEmailActivity = activitiesHandlingEmails.firstOrNull {
             it.loadLabel(packageManager) == name
         } ?: return false
 
-        val specificEmailActivityPackageName = specificEmailActivity.activityInfo.packageName
-        val composeEmailIntent = packageManager.getLaunchIntentForPackage(specificEmailActivityPackageName) ?: return false
+        val composeEmailIntent = Intent(Intent.ACTION_SENDTO).apply {
+            data = Uri.parse("mailto:")
+            type = "text/plain"
+            setClassName(specificEmailActivity.activityInfo.packageName, specificEmailActivity.activityInfo.name)
+            putExtra(Intent.EXTRA_EMAIL, emailContent.to.toTypedArray())
+            putExtra(Intent.EXTRA_CC, emailContent.cc.toTypedArray())
+            putExtra(Intent.EXTRA_BCC, emailContent.bcc.toTypedArray())
+            putExtra(Intent.EXTRA_SUBJECT, emailContent.subject)
+            putExtra(Intent.EXTRA_TEXT, emailContent.body)
+        }
 
         composeEmailIntent.flags = Intent.FLAG_ACTIVITY_NEW_TASK
         applicationContext.startActivity(composeEmailIntent)
@@ -245,10 +250,11 @@ data class App(
         @SerializedName("name") val name: String
 )
 
-data class EmailContent {
-    val to: List<String>
-    val cc: List<String>
-    val bcc: List<String>
-    val subject: String
-    val body: String
-}
+data class EmailContent (
+
+        @SerializedName("to") val to: List<String>,
+        @SerializedName("cc") val cc: List<String>,
+        @SerializedName("bcc") val bcc: List<String>,
+        @SerializedName("subject") val subject: String,
+        @SerializedName("body") val body: String
+)

--- a/android/src/main/kotlin/com/homex/open_mail_app/OpenMailAppPlugin.kt
+++ b/android/src/main/kotlin/com/homex/open_mail_app/OpenMailAppPlugin.kt
@@ -165,7 +165,7 @@ class OpenMailAppPlugin : FlutterPlugin, MethodCallHandler {
                                     putExtra(Intent.EXTRA_SUBJECT, emailContent.subject)
                                     putExtra(Intent.EXTRA_TEXT, emailContent.body)
                                 },
-                            packageName, 
+                            packageName,
                             activityHandlingEmail.loadLabel(packageManager),
                             activityHandlingEmail.icon
                         )

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -49,15 +49,18 @@ class MyApp extends StatelessWidget {
               onPressed: () async {
                 EmailContent email = EmailContent(
                   to: [
-                    'user@localhost',
+                    'user@domain.com',
                   ],
                   subject: 'Hello!',
                   body: 'How are you doing?',
-                  cc: ['user2@localhost', 'user3@localhost'],
-                  bcc: ['boss@localhost'],
+                  cc: ['user2@domain.com', 'user3@domain.com'],
+                  bcc: ['boss@domain.com'],
                 );
 
-                OpenMailAppResult result = await OpenMailApp.composeNewEmailInMailApp(emailContent: email);
+                OpenMailAppResult result =
+                    await OpenMailApp.composeNewEmailInMailApp(
+                        nativePickerTitle: 'Select email app to compose',
+                        emailContent: email);
                 if (!result.didOpen && !result.canOpen) {
                   showNoMailAppsDialog(context);
                 } else if (!result.didOpen && result.canOpen) {
@@ -84,6 +87,15 @@ class MyApp extends StatelessWidget {
                     builder: (context) {
                       return MailAppPickerDialog(
                         mailApps: apps,
+                        emailContent: EmailContent(
+                          to: [
+                            'user@domain.com',
+                          ],
+                          subject: 'Hello!',
+                          body: 'How are you doing?',
+                          cc: ['user2@domain.com', 'user3@domain.com'],
+                          bcc: ['boss@domain.com'],
+                        ),
                       );
                     },
                   );

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -45,9 +45,37 @@ class MyApp extends StatelessWidget {
               },
             ),
             ElevatedButton(
+              child: Text('Open mail app, with email already composed'),
+              onPressed: () async {
+                EmailContent email = EmailContent(
+                  to: [
+                    'user@localhost',
+                  ],
+                  subject: 'Hello!',
+                  body: 'How are you doing?',
+                  cc: ['user2@localhost', 'user3@localhost'],
+                  bcc: ['boss@localhost'],
+                );
+
+                OpenMailAppResult result = await OpenMailApp.composeNewEmailInMailApp(emailContent: email);
+                if (!result.didOpen && !result.canOpen) {
+                  showNoMailAppsDialog(context);
+                } else if (!result.didOpen && result.canOpen) {
+                  showDialog(
+                    context: context,
+                    builder: (_) => MailAppPickerDialog(
+                      mailApps: result.options,
+                      emailContent: email,
+                    ),
+                  );
+                }
+              },
+            ),
+            ElevatedButton(
               child: Text("Get Mail Apps"),
               onPressed: () async {
                 var apps = await OpenMailApp.getMailApps();
+
                 if (apps.isEmpty) {
                   showNoMailAppsDialog(context);
                 } else {

--- a/lib/open_mail_app.dart
+++ b/lib/open_mail_app.dart
@@ -246,7 +246,8 @@ class OpenMailApp {
   static Future<List<MailApp>> _getIosMailApps() async {
     var installedApps = <MailApp>[];
     for (var app in _supportedMailApps) {
-      if (await canLaunch(app.iosLaunchScheme) && !_filterList.contains(app.name.toLowerCase())) {
+      if (await canLaunch(app.iosLaunchScheme) &&
+          !_filterList.contains(app.name.toLowerCase())) {
         installedApps.add(app);
       }
     }
@@ -378,8 +379,8 @@ class MailApp {
 
   factory MailApp.fromJson(Map<String, dynamic> json) => MailApp(
         name: json["name"],
-        iosLaunchScheme: json["iosLaunchScheme"],
-        composeData: json["composeData"],
+        iosLaunchScheme: json["iosLaunchScheme"] ?? '',
+        composeData: json["composeData"] ?? ComposeData(),
       );
 
   Map<String, dynamic> toJson() => {

--- a/lib/open_mail_app.dart
+++ b/lib/open_mail_app.dart
@@ -1,4 +1,3 @@
-import 'dart:async';
 import 'dart:convert';
 import 'dart:io';
 
@@ -7,6 +6,16 @@ import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:url_launcher/url_launcher.dart';
 
+/// Launch Schemes for supported apps:
+const String _LAUNCH_SCHEME_APPLE_MAIL = 'message://';
+const String _LAUNCH_SCHEME_GMAIL = 'googlegmail://';
+const String _LAUNCH_SCHEME_DISPATCH = 'x-dispatch://';
+const String _LAUNCH_SCHEME_SPARK = 'readdle-spark://';
+const String _LAUNCH_SCHEME_AIRMAIL = 'airmail://';
+const String _LAUNCH_SCHEME_OUTLOOK = 'ms-outlook://';
+const String _LAUNCH_SCHEME_YAHOO = 'ymail://';
+const String _LAUNCH_SCHEME_FASTMAIL = 'fastmail://';
+
 /// Provides ability to query device for installed email apps and open those
 /// apps
 class OpenMailApp {
@@ -14,6 +23,66 @@ class OpenMailApp {
 
   static const MethodChannel _channel = const MethodChannel('open_mail_app');
   static List<String> _filterList = <String>['paypal'];
+  static List<MailApp> _supportedMailApps = [
+    MailApp(
+      name: 'Apple Mail',
+      iosLaunchScheme: _LAUNCH_SCHEME_APPLE_MAIL,
+      iosComposeLaunchScheme: ComposeLaunchScheme(
+        base: 'mailto:',
+      ),
+    ),
+    MailApp(
+      name: 'Gmail',
+      iosLaunchScheme: _LAUNCH_SCHEME_GMAIL,
+      iosComposeLaunchScheme: ComposeLaunchScheme(
+        base: _LAUNCH_SCHEME_GMAIL + '/co',
+      ),
+    ),
+    MailApp(
+      name: 'Dispatch',
+      iosLaunchScheme: _LAUNCH_SCHEME_DISPATCH,
+      iosComposeLaunchScheme: ComposeLaunchScheme(
+        base: _LAUNCH_SCHEME_DISPATCH + '/compose',
+      ),
+    ),
+    MailApp(
+      name: 'Spark',
+      iosLaunchScheme: _LAUNCH_SCHEME_SPARK,
+      iosComposeLaunchScheme: ComposeLaunchScheme(
+        base: _LAUNCH_SCHEME_SPARK + 'compose',
+        to: 'recipient=',
+      ),
+    ),
+    MailApp(
+      name: 'Airmail',
+      iosLaunchScheme: _LAUNCH_SCHEME_AIRMAIL,
+      iosComposeLaunchScheme: ComposeLaunchScheme(
+        base: _LAUNCH_SCHEME_AIRMAIL + 'compose',
+        body: 'plainBody=',
+      ),
+    ),
+    MailApp(
+      name: 'Outlook',
+      iosLaunchScheme: _LAUNCH_SCHEME_OUTLOOK,
+      iosComposeLaunchScheme: ComposeLaunchScheme(
+        base: _LAUNCH_SCHEME_OUTLOOK + 'compose',
+      ),
+    ),
+    MailApp(
+      name: 'Yahoo',
+      iosLaunchScheme: _LAUNCH_SCHEME_YAHOO,
+      iosComposeLaunchScheme: ComposeLaunchScheme(
+        base: _LAUNCH_SCHEME_YAHOO + 'mail/compose',
+      ),
+    ),
+    MailApp(
+      name: 'Fastmail',
+      iosLaunchScheme: _LAUNCH_SCHEME_FASTMAIL,
+      iosComposeLaunchScheme: ComposeLaunchScheme(
+        base: _LAUNCH_SCHEME_FASTMAIL + 'mail/compose',
+      ),
+    ),
+  ];
 
   /// Attempts to open an email app installed on the device.
   ///
@@ -27,8 +96,9 @@ class OpenMailApp {
   /// Also see [openSpecificMailApp] and [getMailApps] for other use cases.
   ///
   /// Android: [nativePickerTitle] will set the title of the native picker.
-  static Future<OpenMailAppResult> openMailApp(
-      {String nativePickerTitle = ''}) async {
+  static Future<OpenMailAppResult> openMailApp({
+    String nativePickerTitle = '',
+  }) async {
     if (Platform.isAndroid) {
       var result = await _channel.invokeMethod<bool>(
             'openMailApp',
@@ -40,7 +110,7 @@ class OpenMailApp {
       var apps = await _getIosMailApps();
       if (apps.length == 1) {
         var result = await launch(
-          apps.first.iosLaunchScheme!,
+          apps.first.iosLaunchScheme,
           forceSafariVC: false,
         );
         return OpenMailAppResult(didOpen: result);
@@ -50,6 +120,62 @@ class OpenMailApp {
     } else {
       throw Exception('Platform not supported');
     }
+  }
+
+  /// Allows you to open a mail application installed on the user's device
+  /// and start composing a new email with the contents in [emailContent].
+  ///
+  /// [EmailContent] Provides content for  the email you're composing
+  /// [String] (android) sets the title of the native picker.
+  /// throws an [Exception] if you're launching from an unsupported platform.
+  static Future<OpenMailAppResult> composeNewEmailInMailApp({
+    String nativePickerTitle = '',
+    EmailContent? emailContent,
+  }) async {
+    if (Platform.isAndroid) {
+      return Future.value(OpenMailAppResult(didOpen: false));
+    } else if (Platform.isIOS) {
+      List<MailApp> installedApps = await _getIosMailApps();
+      if (installedApps.length == 1) {
+        bool result = await launch(
+          installedApps.first.iosLaunchScheme,
+          forceSafariVC: false,
+        );
+        return OpenMailAppResult(didOpen: result);
+      } else {
+        // This is pretty shit since you can't do anything with this...
+        // Need to adapt the flow with that popup to also allow to pass emailcontent there.
+        return OpenMailAppResult(didOpen: false, options: installedApps);
+      }
+    } else {
+      throw Exception('Platform currently not supported.');
+    }
+  }
+
+  /// Allows you to compose a new email in the specified [mailApp] witht the
+  /// contents from [emailContent]
+  ///
+  /// [MailApp] (required) the maill app you wish to launch. Get it by calling [getMailApps]
+  /// [EmailContent] provides content for the email you're composing
+  /// throws an [Exception] if you're launching from an unsupported platform.
+  static Future<bool> composeNewEmailInSpecificMailApp({
+    required MailApp mailApp,
+    required EmailContent emailContent,
+  }) async {
+    if (Platform.isAndroid) {
+    } else if (Platform.isIOS) {
+      String? launchScheme = mailApp.composeLaunchScheme(emailContent);
+      print(launchScheme);
+      if (launchScheme != null) {
+        return await launch(launchScheme);
+      }
+
+      return false;
+    } else {
+      throw Exception('Platform currently not supported');
+    }
+
+    return false;
   }
 
   /// Attempts to open a specific email app installed on the device.
@@ -63,14 +189,10 @@ class OpenMailApp {
           false;
       return result;
     } else if (Platform.isIOS) {
-      if (mailApp.iosLaunchScheme != null) {
-        return await launch(
-          mailApp.iosLaunchScheme!,
-          forceSafariVC: false,
-        );
-      }
-
-      return false;
+      return await launch(
+        mailApp.iosLaunchScheme,
+        forceSafariVC: false,
+      );
     } else {
       throw Exception('Platform not supported');
     }
@@ -105,9 +227,8 @@ class OpenMailApp {
 
   static Future<List<MailApp>> _getIosMailApps() async {
     var installedApps = <MailApp>[];
-    for (var app in _IosLaunchSchemes.mailApps) {
-      if (await canLaunch(app.iosLaunchScheme!) &&
-          !_filterList.contains(app.name.toLowerCase())) {
+    for (var app in _supportedMailApps) {
+      if (await canLaunch(app.iosLaunchScheme) && !_filterList.contains(app.name.toLowerCase())) {
         installedApps.add(app);
       }
     }
@@ -135,11 +256,13 @@ class MailAppPickerDialog extends StatelessWidget {
 
   /// The mail apps for the dialog to provide as options
   final List<MailApp> mailApps;
+  final EmailContent? emailContent;
 
   const MailAppPickerDialog({
     Key? key,
     this.title = 'Choose Mail App',
     required this.mailApps,
+    this.emailContent,
   }) : super(key: key);
 
   @override
@@ -151,7 +274,15 @@ class MailAppPickerDialog extends StatelessWidget {
           SimpleDialogOption(
             child: Text(app.name),
             onPressed: () {
-              OpenMailApp.openSpecificMailApp(app);
+              if (emailContent == null) {
+                OpenMailApp.openSpecificMailApp(app);
+              } else {
+                OpenMailApp.composeNewEmailInSpecificMailApp(
+                  mailApp: app,
+                  emailContent: emailContent!,
+                );
+              }
+
               Navigator.pop(context);
             },
           ),
@@ -160,24 +291,105 @@ class MailAppPickerDialog extends StatelessWidget {
   }
 }
 
+class ComposeLaunchScheme {
+  String base;
+  String to;
+  String cc;
+  String bcc;
+  String subject;
+  String body;
+  bool composeStarted = false;
+  String get qsPairSeparator {
+    String separator = !composeStarted ? '?' : '&';
+    composeStarted = true;
+    return separator;
+  }
+
+  ComposeLaunchScheme({
+    required this.base,
+    this.to = 'to=',
+    this.cc = 'cc=',
+    this.bcc = 'bcc=',
+    this.subject = 'subject=',
+    this.body = 'body=',
+  });
+
+  String getComposeLaunchScheme(EmailContent content) {
+    String scheme = base;
+    if (content.to.isNotEmpty) {
+      scheme += '$qsPairSeparator${this.to + content.to}';
+    }
+    if (content.cc.isNotEmpty) {
+      scheme += '$qsPairSeparator${this.cc + content.cc}';
+    }
+
+    if (content.bcc.isNotEmpty) {
+      scheme += '$qsPairSeparator${this.bcc + content.bcc}';
+    }
+
+    if (content.subject.isNotEmpty) {
+      scheme += '$qsPairSeparator${this.subject + content.subject}';
+    }
+
+    if (content.body.isNotEmpty) {
+      scheme += '$qsPairSeparator${this.body + content.body}';
+    }
+
+    // Reset to make sure you can fetch this multiple times on the same instance.
+    composeStarted = false;
+
+    return scheme;
+  }
+
+  @override
+  String toString() {
+    return this.getComposeLaunchScheme(EmailContent());
+  }
+}
+
 class MailApp {
   final String name;
-  final String? iosLaunchScheme;
+  final String iosLaunchScheme;
+  final ComposeLaunchScheme? _iosComposeLaunchScheme;
+  final ComposeLaunchScheme? _androidComposeLaunchScheme;
 
   const MailApp({
     required this.name,
-    this.iosLaunchScheme,
-  });
+    required this.iosLaunchScheme,
+    ComposeLaunchScheme? androidComposeLaunchScheme,
+    ComposeLaunchScheme? iosComposeLaunchScheme,
+  })  : this._androidComposeLaunchScheme = androidComposeLaunchScheme,
+        this._iosComposeLaunchScheme = iosComposeLaunchScheme;
 
   factory MailApp.fromJson(Map<String, dynamic> json) => MailApp(
         name: json["name"],
         iosLaunchScheme: json["iosLaunchScheme"],
+        iosComposeLaunchScheme: json["iosComposeLaunchScheme"],
+        androidComposeLaunchScheme: json["androidComposeLaunchScheme"],
       );
 
   Map<String, dynamic> toJson() => {
         "name": name,
         "iosLaunchScheme": iosLaunchScheme,
+        "iosComposeLaunchScheme": _iosComposeLaunchScheme,
+        "androidComposeLaunchScheme": _androidComposeLaunchScheme,
       };
+
+  // String _interpolateQueryParams(String base, EmailContent content) {
+
+  //   return
+  // }
+
+  String? composeLaunchScheme(EmailContent content) {
+    if (Platform.isAndroid) {
+      // return this._androidComposeLaunchScheme;
+      return 'TODO';
+    } else if (Platform.isIOS) {
+      return this._iosComposeLaunchScheme!.getComposeLaunchScheme(content);
+    } else {
+      throw Exception('Platform not supported');
+    }
+  }
 }
 
 /// Result of calling [OpenMailApp.openMailApp]
@@ -195,26 +407,31 @@ class OpenMailAppResult {
   });
 }
 
-class _IosLaunchSchemes {
-  _IosLaunchSchemes._();
+/// Used to populate the precomposed emails
+///
+/// [to] List of Addressees, will be joined on a ,
+/// [cc] Carbon Copy list, will be joined on a,
+/// [bcc] Blind carbon copy list, will be joined on a,
+/// [subject] [String], getter returns [Uri.encodeComponent] from the set [String]
+/// [body] [String], getter returns [Uri.encodeComponent] from the set [String]
+class EmailContent {
+  final String to;
+  final String cc;
+  final String bcc;
+  final String _subject;
+  String get subject => Uri.encodeComponent(_subject);
+  final String _body;
+  String get body => Uri.encodeComponent(_body);
 
-  static const apple = 'message://';
-  static const gmail = 'googlegmail://';
-  static const dispatch = 'x-dispatch://';
-  static const spark = 'readdle-spark://';
-  static const airmail = 'airmail://';
-  static const outlook = 'ms-outlook://';
-  static const yahoo = 'ymail://';
-  static const fastmail = 'fastmail://';
-
-  static const mailApps = [
-    MailApp(name: 'Mail', iosLaunchScheme: apple),
-    MailApp(name: 'Gmail', iosLaunchScheme: gmail),
-    MailApp(name: 'Dispatch', iosLaunchScheme: dispatch),
-    MailApp(name: 'Spark', iosLaunchScheme: spark),
-    MailApp(name: 'Airmail', iosLaunchScheme: airmail),
-    MailApp(name: 'Outlook', iosLaunchScheme: outlook),
-    MailApp(name: 'Yahoo', iosLaunchScheme: yahoo),
-    MailApp(name: 'Fastmail', iosLaunchScheme: fastmail),
-  ];
+  EmailContent({
+    List<String>? to,
+    List<String>? cc,
+    List<String>? bcc,
+    String? subject,
+    String? body,
+  })  : this.to = (to ?? const []).join(','),
+        this.cc = (cc ?? const []).join(','),
+        this.bcc = (bcc ?? const []).join(','),
+        this._subject = subject ?? '',
+        this._body = body ?? '';
 }

--- a/lib/open_mail_app.dart
+++ b/lib/open_mail_app.dart
@@ -340,23 +340,25 @@ class ComposeData {
 
   String getComposeLaunchSchemeForIos(EmailContent content) {
     String scheme = base;
+    
     if (content.to.isNotEmpty) {
-      scheme += '$qsPairSeparator${this.to}=${content.to.join(',')}';
+      scheme += '$qsPairSeparator$to=${content.to.join(',')}';
     }
+    
     if (content.cc.isNotEmpty) {
-      scheme += '$qsPairSeparator${this.cc}=${content.cc.join(',')}';
+      scheme += '$qsPairSeparator$cc=${content.cc.join(',')}';
     }
 
     if (content.bcc.isNotEmpty) {
-      scheme += '$qsPairSeparator${this.bcc}=${content.bcc.join(',')}';
+      scheme += '$qsPairSeparator$bcc=${content.bcc.join(',')}';
     }
 
     if (content.subject.isNotEmpty) {
-      scheme += '$qsPairSeparator${this.subject}=${content.subject}';
+      scheme += '$qsPairSeparator$subject=${content.subject}';
     }
 
     if (content.body.isNotEmpty) {
-      scheme += '$qsPairSeparator${this.body}=${content.body}';
+      scheme += '$qsPairSeparator$body=${content.body}';
     }
 
     // Reset to make sure you can fetch this multiple times on the same instance.

--- a/lib/open_mail_app.dart
+++ b/lib/open_mail_app.dart
@@ -427,9 +427,10 @@ class EmailContent {
   final List<String> cc;
   final List<String> bcc;
   final String _subject;
-  String get subject => Uri.encodeComponent(_subject);
+  String get subject =>
+      Platform.isIOS ? Uri.encodeComponent(_subject) : _subject;
   final String _body;
-  String get body => Uri.encodeComponent(_body);
+  String get body => Platform.isIOS ? Uri.encodeComponent(_body) : _body;
 
   EmailContent({
     List<String>? to,

--- a/lib/open_mail_app.dart
+++ b/lib/open_mail_app.dart
@@ -298,13 +298,14 @@ class MailAppPickerDialog extends StatelessWidget {
           SimpleDialogOption(
             child: Text(app.name),
             onPressed: () {
-              if (emailContent == null) {
-                OpenMailApp.openSpecificMailApp(app);
-              } else {
+              final content = this.emailContent;
+              if (content != null) {
                 OpenMailApp.composeNewEmailInSpecificMailApp(
                   mailApp: app,
-                  emailContent: emailContent!,
+                  emailContent: content,
                 );
+              } else {
+                OpenMailApp.openSpecificMailApp(app);
               }
 
               Navigator.pop(context);
@@ -340,11 +341,11 @@ class ComposeData {
 
   String getComposeLaunchSchemeForIos(EmailContent content) {
     String scheme = base;
-    
+
     if (content.to.isNotEmpty) {
       scheme += '$qsPairSeparator$to=${content.to.join(',')}';
     }
-    
+
     if (content.cc.isNotEmpty) {
       scheme += '$qsPairSeparator$cc=${content.cc.join(',')}';
     }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: open_mail_app
 description: This library provides the ability to query the device for installed email apps and open those apps
-version: 0.1.1
+version: 0.2.0
 homepage: https://github.com/HomeXLabs/open-mail-app-flutter
 
 environment:


### PR DESCRIPTION
Building on the work started by @azorychta. All of the launch schemes were taken from their PR.

Built in collaboration with @krispypen. 
Supported on android and iOS for the `to`, `cc`, `bcc`, `subject` and `body` fields.
 
Should close https://github.com/HomeXLabs/open-mail-app-flutter/issues/6