### PR TITLE
Platform native pickers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 0.5.0
+
+- Replace `MailAppPickerDialog` with `OpenMailApp.showMailPicker()` function, which shows SimpleDialog on Android and CupertinoActionSheet on iOS
+- Update for Android dependencies
+
 ## 0.4.1
 Thanks to LosDanieloss for the following fix
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## 0.5.0
 
-- Replace `MailAppPickerDialog` with `OpenMailApp.showMailPicker()` function, which shows SimpleDialog on Android and CupertinoActionSheet on iOS
+- BREAKING CHANGE: Replace `MailAppPickerDialog` with `OpenMailApp.showMailPicker()` function, which shows SimpleDialog on Android and CupertinoActionSheet on iOS
 - Update for Android dependencies
 
 ## 0.4.1

--- a/README.md
+++ b/README.md
@@ -39,8 +39,8 @@ void main() {
 class MyApp extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
-    return RaisedButton(
-      child: Text("Open Mail App"),
+    return ElevatedButton(
+      child: Text('Open Mail App'),
       onPressed: () async {
         // Android: Will open mail app or show native picker.
         // iOS: Will open mail app if single mail app found.
@@ -50,17 +50,11 @@ class MyApp extends StatelessWidget {
         if (!result.didOpen && !result.canOpen) {
           showNoMailAppsDialog(context);
 
-          // iOS: if multiple mail apps found, show dialog to select.
-          // There is no native intent/default app system in iOS so
-          // you have to do it yourself.
+          // iOS: if multiple mail apps found, show action sheet to select.
         } else if (!result.didOpen && result.canOpen) {
-          showDialog(
-            context: context,
-            builder: (_) {
-              return MailAppPickerDialog(
-                mailApps: result.options,
-              );
-            },
+          OpenMailApp.showMailPicker(
+            context,
+            mailApps: result.options,
           );
         }
       },
@@ -72,11 +66,11 @@ class MyApp extends StatelessWidget {
       context: context,
       builder: (context) {
         return AlertDialog(
-          title: Text("Open Mail App"),
-          content: Text("No mail apps installed"),
+          title: Text('Open Mail App'),
+          content: Text('No mail apps installed'),
           actions: <Widget>[
-            FlatButton(
-              child: Text("OK"),
+            TextButton(
+              child: Text('OK'),
               onPressed: () {
                 Navigator.pop(context);
               },

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -2,14 +2,14 @@ group 'com.homex.open_mail_app'
 version '1.0-SNAPSHOT'
 
 buildscript {
-    ext.kotlin_version = '1.3.71'
+    ext.kotlin_version = '1.6.0'
     repositories {
         google()
         jcenter()
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.6.4'
+        classpath 'com.android.tools.build:gradle:7.0.3'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
     }
 }
@@ -39,6 +39,6 @@ android {
 }
 
 dependencies {
-    implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
-    implementation 'com.google.code.gson:gson:2.8.5'
+    implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
+    implementation 'com.google.code.gson:gson:2.8.9'
 }

--- a/android/gradle.properties
+++ b/android/gradle.properties
@@ -1,4 +1,3 @@
 org.gradle.jvmargs=-Xmx1536M
 android.enableR8=true
 android.useAndroidX=true
-android.enableJetifier=true

--- a/example/android/app/build.gradle
+++ b/example/android/app/build.gradle
@@ -64,5 +64,5 @@ flutter {
 }
 
 dependencies {
-    implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
+    implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
 }

--- a/example/android/build.gradle
+++ b/example/android/build.gradle
@@ -1,12 +1,12 @@
 buildscript {
-    ext.kotlin_version = '1.3.71'
+    ext.kotlin_version = '1.6.0'
     repositories {
         google()
         jcenter()
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.6.4'
+        classpath 'com.android.tools.build:gradle:7.0.3'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
     }
 }

--- a/example/android/gradle.properties
+++ b/example/android/gradle.properties
@@ -1,4 +1,16 @@
+## For more details on how to configure your build environment visit
+# http://www.gradle.org/docs/current/userguide/build_environment.html
+#
+# Specifies the JVM arguments used for the daemon process.
+# The setting is particularly useful for tweaking memory settings.
+# Default value: -Xmx1024m -XX:MaxPermSize=256m
+# org.gradle.jvmargs=-Xmx2048m -XX:MaxPermSize=512m -XX:+HeapDumpOnOutOfMemoryError -Dfile.encoding=UTF-8
+#
+# When configured, Gradle will run in incubating parallel mode.
+# This option should only be used with decoupled projects. More details, visit
+# http://www.gradle.org/docs/current/userguide/multi_project_builds.html#sec:decoupled_projects
+# org.gradle.parallel=true
+#Sat Nov 20 15:51:41 EET 2021
 org.gradle.jvmargs=-Xmx1536M
-android.enableR8=true
 android.useAndroidX=true
 android.enableJetifier=true

--- a/example/android/gradle/wrapper/gradle-wrapper.properties
+++ b/example/android/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-5.6.4-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.2-all.zip

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -33,13 +33,9 @@ class MyApp extends StatelessWidget {
                   // There is no native intent/default app system in iOS so
                   // you have to do it yourself.
                 } else if (!result.didOpen && result.canOpen) {
-                  showDialog(
-                    context: context,
-                    builder: (_) {
-                      return MailAppPickerDialog(
-                        mailApps: result.options,
-                      );
-                    },
+                  OpenMailApp.showMailPicker(
+                    context,
+                    mailApps: result.options,
                   );
                 }
               },
@@ -64,12 +60,10 @@ class MyApp extends StatelessWidget {
                 if (!result.didOpen && !result.canOpen) {
                   showNoMailAppsDialog(context);
                 } else if (!result.didOpen && result.canOpen) {
-                  showDialog(
-                    context: context,
-                    builder: (_) => MailAppPickerDialog(
-                      mailApps: result.options,
-                      emailContent: email,
-                    ),
+                  OpenMailApp.showMailPicker(
+                    context,
+                    mailApps: result.options,
+                    emailContent: email,
                   );
                 }
               },
@@ -82,22 +76,18 @@ class MyApp extends StatelessWidget {
                 if (apps.isEmpty) {
                   showNoMailAppsDialog(context);
                 } else {
-                  showDialog(
-                    context: context,
-                    builder: (context) {
-                      return MailAppPickerDialog(
-                        mailApps: apps,
-                        emailContent: EmailContent(
-                          to: [
-                            'user@domain.com',
-                          ],
-                          subject: 'Hello!',
-                          body: 'How are you doing?',
-                          cc: ['user2@domain.com', 'user3@domain.com'],
-                          bcc: ['boss@domain.com'],
-                        ),
-                      );
-                    },
+                  OpenMailApp.showMailPicker(
+                    context,
+                    mailApps: apps,
+                    emailContent: EmailContent(
+                      to: [
+                        'user@domain.com',
+                      ],
+                      subject: 'Hello!',
+                      body: 'How are you doing?',
+                      cc: ['user2@domain.com', 'user3@domain.com'],
+                      bcc: ['boss@domain.com'],
+                    ),
                   );
                 }
               },

--- a/lib/mail_picker_dialog_android.dart
+++ b/lib/mail_picker_dialog_android.dart
@@ -1,0 +1,51 @@
+import 'package:flutter/material.dart';
+
+import 'open_mail_app.dart';
+
+/// A simple dialog for allowing the user to pick and open an email app
+/// Use with [OpenMailApp.getMailApps] or [OpenMailApp.openMailApp] to get a
+/// list of mail apps installed on the device.
+class MailAppPickerDialogAndroid extends StatelessWidget {
+  /// The title of the dialog
+  final String title;
+  /// The title for cancel button of the dialog
+  final String cancelButtonTitle;
+
+  /// The mail apps for the dialog to provide as options
+  final List<MailApp> mailApps;
+  final EmailContent? emailContent;
+
+  const MailAppPickerDialogAndroid({
+    Key? key,
+    required this.title,
+    required this.cancelButtonTitle,
+    required this.mailApps,
+    this.emailContent,
+  }) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    return SimpleDialog(
+      title: Text(title),
+      children: <Widget>[
+        for (var app in mailApps)
+          SimpleDialogOption(
+            child: Text(app.name),
+            onPressed: () {
+              final content = this.emailContent;
+              if (content != null) {
+                OpenMailApp.composeNewEmailInSpecificMailApp(
+                  mailApp: app,
+                  emailContent: content,
+                );
+              } else {
+                OpenMailApp.openSpecificMailApp(app);
+              }
+
+              Navigator.pop(context);
+            },
+          ),
+      ],
+    );
+  }
+}

--- a/lib/mail_picker_dialog_android.dart
+++ b/lib/mail_picker_dialog_android.dart
@@ -8,6 +8,7 @@ import 'open_mail_app.dart';
 class MailAppPickerDialogAndroid extends StatelessWidget {
   /// The title of the dialog
   final String title;
+
   /// The title for cancel button of the dialog
   final String cancelButtonTitle;
 

--- a/lib/mail_picker_dialog_ios.dart
+++ b/lib/mail_picker_dialog_ios.dart
@@ -1,0 +1,59 @@
+import 'package:flutter/cupertino.dart';
+
+import 'open_mail_app.dart';
+
+/// A simple dialog for allowing the user to pick and open an email app
+/// Use with [OpenMailApp.getMailApps] or [OpenMailApp.openMailApp] to get a
+/// list of mail apps installed on the device.
+class MailAppPickerDialogIOS extends StatelessWidget {
+  /// The title of the dialog
+  final String title;
+
+  /// The title for cancel button of the dialog
+  final String cancelButtonTitle;
+
+  /// The mail apps for the dialog to provide as options
+  final List<MailApp> mailApps;
+  final EmailContent? emailContent;
+
+  const MailAppPickerDialogIOS({
+    Key? key,
+    required this.title,
+    required this.cancelButtonTitle,
+    required this.mailApps,
+    this.emailContent,
+  }) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    return CupertinoActionSheet(
+      title: Text(title),
+      cancelButton: CupertinoActionSheetAction(
+        child: Text(
+          cancelButtonTitle,
+          style: TextStyle(fontWeight: FontWeight.bold),
+        ),
+        onPressed: () => Navigator.pop(context),
+      ),
+      actions: <Widget>[
+        for (var app in mailApps)
+          CupertinoActionSheetAction(
+            child: Text(app.name),
+            onPressed: () {
+              final content = this.emailContent;
+              if (content != null) {
+                OpenMailApp.composeNewEmailInSpecificMailApp(
+                  mailApp: app,
+                  emailContent: content,
+                );
+              } else {
+                OpenMailApp.openSpecificMailApp(app);
+              }
+
+              Navigator.pop(context);
+            },
+          ),
+      ],
+    );
+  }
+}

--- a/lib/open_mail_app.dart
+++ b/lib/open_mail_app.dart
@@ -294,6 +294,16 @@ class OpenMailApp {
     _filterList = filterList.map((e) => e.toLowerCase()).toList();
   }
 
+  /// Shows platform-dependent picker allowing the user to pick and open an email app
+  /// On Android it will show a SimpleDialog widget.
+  /// On iOS it will show CupertinoActionSheet widget.
+  /// Use with [OpenMailApp.getMailApps] or [OpenMailApp.openMailApp] to get a
+  /// list of mail apps installed on the device.
+  /// [context] BuildContext
+  /// [mailApps] list of apps received from [OpenMailApp.getMailApps], [OpenMailApp.openMailApp] or [OpenMailApp.composeNewEmailInMailApp]
+  /// [emailContent] provides content for the email you're composing
+  /// [pickerTitle] title of dialog/action sheet
+  /// [cancel] Text for Cancel button. For iOS only, since Android dialog has no Cancel button
   static Future<void> showMailPicker(
     BuildContext context, {
     required List<MailApp> mailApps,

--- a/lib/open_mail_app.dart
+++ b/lib/open_mail_app.dart
@@ -1,8 +1,11 @@
 import 'dart:convert';
 
+import 'package:flutter/cupertino.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
+import 'package:open_mail_app/mail_picker_dialog_android.dart';
+import 'package:open_mail_app/mail_picker_dialog_ios.dart';
 import 'package:platform/platform.dart';
 import 'package:url_launcher/url_launcher.dart';
 
@@ -290,50 +293,37 @@ class OpenMailApp {
   static void setFilterList(List<String> filterList) {
     _filterList = filterList.map((e) => e.toLowerCase()).toList();
   }
-}
 
-/// A simple dialog for allowing the user to pick and open an email app
-/// Use with [OpenMailApp.getMailApps] or [OpenMailApp.openMailApp] to get a
-/// list of mail apps installed on the device.
-class MailAppPickerDialog extends StatelessWidget {
-  /// The title of the dialog
-  final String title;
-
-  /// The mail apps for the dialog to provide as options
-  final List<MailApp> mailApps;
-  final EmailContent? emailContent;
-
-  const MailAppPickerDialog({
-    Key? key,
-    this.title = 'Choose Mail App',
-    required this.mailApps,
-    this.emailContent,
-  }) : super(key: key);
-
-  @override
-  Widget build(BuildContext context) {
-    return SimpleDialog(
-      title: Text(title),
-      children: <Widget>[
-        for (var app in mailApps)
-          SimpleDialogOption(
-            child: Text(app.name),
-            onPressed: () {
-              final content = this.emailContent;
-              if (content != null) {
-                OpenMailApp.composeNewEmailInSpecificMailApp(
-                  mailApp: app,
-                  emailContent: content,
-                );
-              } else {
-                OpenMailApp.openSpecificMailApp(app);
-              }
-
-              Navigator.pop(context);
-            },
-          ),
-      ],
-    );
+  static Future<void> showMailPicker(
+    BuildContext context, {
+    required List<MailApp> mailApps,
+    EmailContent? emailContent,
+    String pickerTitle = 'Choose Mail App',
+    String cancelButtonTitle = 'Cancel',
+  }) {
+    if (_isAndroid) {
+      return showDialog(
+          context: context,
+          builder: (_) {
+            return MailAppPickerDialogAndroid(
+              title: pickerTitle,
+              cancelButtonTitle: cancelButtonTitle,
+              mailApps: mailApps,
+              emailContent: emailContent,
+            );
+          });
+    } else {
+      return showCupertinoModalPopup(
+          context: context,
+          builder: (_) {
+            return MailAppPickerDialogIOS(
+              title: pickerTitle,
+              cancelButtonTitle: cancelButtonTitle,
+              mailApps: mailApps,
+              emailContent: emailContent,
+            );
+          });
+    }
   }
 }
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: open_mail_app
 description: This library provides the ability to query the device for installed email apps and open those apps
-version: 0.4.1
+version: 0.5.0
 homepage: https://github.com/HomeXLabs/open-mail-app-flutter
 
 environment:


### PR DESCRIPTION
This PR replaces `MailAppPickerDialog` with a function, which takes care for user to create proper ActionSheet on iOS design making the picker look more or less native to the platform. 
Decided to not hide dialogs classes from users in case there is need to use one of them, but not sure if it was a good move.

Except for that also bumped some Android related dependencies and updated README with non-deprecated buttons in code example.

Did a minor version change due to introduced change, but feel that, ideally, such changed should be a major version change, since it is not backwards compatible. However, I don't know plans on reaching 1.0.0 for this plugin, so went with just minor bump.

Here is how iOS picker looks with introduced changes.
<img src="https://user-images.githubusercontent.com/13467769/142730362-9f364737-a215-4c3e-b86a-bfda576eeca6.jpeg" height="400" />

