### PR TITLE
chore: android migrate to mavenCentral

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.4.3
+
+- Android: migrate from jcenter to mavenCentral
+
 ## 0.4.2
 Thanks to deathcoder for the following fix
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,13 +1,15 @@
 ## 0.4.3
 
 - Android: migrate from jcenter to mavenCentral
+- Updated Gradle to 7.0.2
+- Updated Gradle Build Tools to 7.0.4
 
 ## 0.4.2
 Thanks to deathcoder for the following fix
 
 - Updated Kotlin to 1.6.10
-- Updated Gradle to 7.0.2
-- Updated Gradle Build Tools to 7.0.4
+- Updated Gradle to 7.0.2 (example)
+- Updated Gradle Build Tools to 7.0.4 (example)
 
 ## 0.4.1
 Thanks to LosDanieloss for the following fix

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -5,7 +5,7 @@ buildscript {
     ext.kotlin_version = '1.6.10'
     repositories {
         google()
-        jcenter()
+        mavenCentral()
     }
 
     dependencies {
@@ -17,7 +17,7 @@ buildscript {
 rootProject.allprojects {
     repositories {
         google()
-        jcenter()
+        mavenCentral()
     }
 }
 

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -9,7 +9,7 @@ buildscript {
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.6.4'
+        classpath 'com.android.tools.build:gradle:7.0.4'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
     }
 }

--- a/android/gradle/wrapper/gradle-wrapper.properties
+++ b/android/gradle/wrapper/gradle-wrapper.properties
@@ -2,4 +2,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.7.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.0.2-all.zip

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: open_mail_app
 description: This library provides the ability to query the device for installed email apps and open those apps
-version: 0.4.2
+version: 0.4.3
 homepage: https://github.com/HomeXLabs/open-mail-app-flutter
 
 environment:


### PR DESCRIPTION
Android:
- migrate to `mavenCentral`
- update Gradle